### PR TITLE
Object mode view/edit

### DIFF
--- a/extprogs/extprogs.go
+++ b/extprogs/extprogs.go
@@ -62,7 +62,7 @@ func ViewFile(filePath string) error {
 // Edit shows given bytes in external text editor and returns changed contents
 // of file if file is changed
 func Edit(name string, content []byte) (changed bool, newContent []byte, returnError error) {
-	logging.LogDebug("extprogs/Edit() ", name)
+	logging.LogDebugf("extprogs/Edit('%s', ..) ", name)
 	if config.Conf.Cmd.Editor == "" {
 		return false, nil, errors.New("Editor command not configured.")
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/antchfx/jsonquery v0.0.0-20180821084212-a2896be8c82b
 	github.com/antchfx/xmlquery v1.0.0
 	github.com/antchfx/xpath v1.1.1 // indirect
+	github.com/clbanning/mxj v1.8.4
 	github.com/croz-ltd/confident v0.0.2
 	github.com/gdamore/tcell v1.3.0
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/antchfx/xmlquery v1.0.0 h1:YuEPqexGG2opZKNc9JU3Zw6zFXwC47wNcy6/F8oKsr
 github.com/antchfx/xmlquery v1.0.0/go.mod h1:/+CnyD/DzHRnv2eRxrVbieRU/FIF6N0C+7oTtyUtCKk=
 github.com/antchfx/xpath v1.1.1 h1:mqGYmd5pioPu06+REIf8j3y6O3S1UpVNVoCameZHotg=
 github.com/antchfx/xpath v1.1.1/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
+github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/croz-ltd/confident v0.0.2 h1:utqZJvn8MRoK4SI3ZOV5CWsKbxyfO3jFD/Hv6msGs80=
 github.com/croz-ltd/confident v0.0.2/go.mod h1:25U9yeNuVXYmCyA+AUZmNc8C3lqgY71HtQ1/wj0iIhg=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=

--- a/help/help.go
+++ b/help/help.go
@@ -43,6 +43,9 @@ p                   - find previous string
 f                   - filter shown items by string
 .                   - enter location (full path) for local file system
 s                   - auto-synchronize selected directories (local to dp)
+0                   - toggle DataPower view from filestore view to object view (TODO)
++                   - when showing DataPower object view show only classes
+                      for which objects exists (TODO)
 q                   - quit
 any-other-char      - show help (+ hex value of key pressed visible in status bar)
 

--- a/model/model.go
+++ b/model/model.go
@@ -39,6 +39,10 @@ func (it ItemType) UserFriendlyString() string {
 		return "domain"
 	case ItemDpFilestore:
 		return "filestore"
+	case ItemDpObjectClass:
+		return "object class"
+	case ItemDpObject:
+		return "object"
 	case ItemNone:
 		return "-"
 	default:
@@ -53,6 +57,8 @@ const (
 	ItemDpConfiguration = ItemType('A')
 	ItemDpDomain        = ItemType('D')
 	ItemDpFilestore     = ItemType('F')
+	ItemDpObjectClass   = ItemType('C')
+	ItemDpObject        = ItemType('O')
 	ItemNone            = ItemType('-')
 	ItemAny             = ItemType('*')
 )
@@ -147,9 +153,20 @@ func (items ItemList) Len() int {
 
 // Less returns true if item at first index should be before second one.
 func (items ItemList) Less(i, j int) bool {
-	return items[i].Config.Type < items[j].Config.Type ||
-		(items[i].Config.Type == items[j].Config.Type &&
-			strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name))
+	switch {
+	case items[i].Name == ".." && items[j].Name != "..":
+		return true
+	case items[i].Name != ".." && items[j].Name == "..":
+		return false
+	case items[i].Config.Type == ItemDirectory && items[j].Config.Type == ItemFile:
+		return true
+	case items[i].Config.Type == ItemFile && items[j].Config.Type == ItemDirectory:
+		return false
+	case items[i].Config.Type == items[j].Config.Type:
+		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+	default:
+		return false
+	}
 }
 
 // Swap swaps items with given indices.

--- a/model/model.go
+++ b/model/model.go
@@ -304,11 +304,12 @@ func (m *Model) SetCurrItemForSide(side Side, itemName string) {
 func (m *Model) SetCurrItemForSideAndConfig(side Side, config *ItemConfig) {
 	itemIdx := 0
 	for idx, item := range m.items[m.currSide] {
-		if item.Config.Path == config.Path {
+		if item.Config.Path == config.Path && item.Config.DpDomain == config.DpDomain && item.Config.DpAppliance == config.DpAppliance {
 			itemIdx = idx
 			break
 		}
 	}
+
 	logging.LogDebugf("model/SetCurrItemForSideAndConfig(%v, %v), itemIdx: %v", side, config, itemIdx)
 	m.currItemIdx[m.currSide] = itemIdx
 }

--- a/model/model.go
+++ b/model/model.go
@@ -303,15 +303,18 @@ func (m *Model) SetCurrItemForSide(side Side, itemName string) {
 // SetCurrItemForSideAndConfig sets current item under cursor for Side to ItemConfig.
 func (m *Model) SetCurrItemForSideAndConfig(side Side, config *ItemConfig) {
 	itemIdx := 0
-	for idx, item := range m.items[m.currSide] {
-		if item.Config.Path == config.Path && item.Config.DpDomain == config.DpDomain && item.Config.DpAppliance == config.DpAppliance {
+	for idx, item := range m.items[side] {
+		if item.Config.Path == config.Path &&
+			item.Config.DpDomain == config.DpDomain &&
+			item.Config.DpAppliance == config.DpAppliance {
 			itemIdx = idx
 			break
 		}
 	}
 
 	logging.LogDebugf("model/SetCurrItemForSideAndConfig(%v, %v), itemIdx: %v", side, config, itemIdx)
-	m.currItemIdx[m.currSide] = itemIdx
+	m.currItemIdx[side] = itemIdx
+	m.navUpDown(side, 0)
 }
 
 // CurrItem returns current item under cursor for used side.

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -10,8 +10,9 @@ import (
 // ItemType methods tests
 
 func TestItemTypeString(t *testing.T) {
-	types := []ItemType{ItemFile, ItemDirectory, ItemDpConfiguration, ItemDpDomain, ItemDpFilestore, ItemNone}
-	wantArr := []string{"f", "d", "A", "D", "F", "-"}
+	types := []ItemType{ItemFile, ItemDirectory, ItemDpConfiguration, ItemDpDomain,
+		ItemDpFilestore, ItemDpObjectClass, ItemDpObject, ItemNone}
+	wantArr := []string{"f", "d", "A", "D", "F", "C", "O", "-"}
 
 	for idx, gotType := range types {
 		got := gotType.String()
@@ -21,8 +22,10 @@ func TestItemTypeString(t *testing.T) {
 }
 
 func TestUserFriendlyString(t *testing.T) {
-	types := []ItemType{ItemFile, ItemDirectory, ItemDpConfiguration, ItemDpDomain, ItemDpFilestore, ItemNone}
-	wantArr := []string{"file", "directory", "appliance configuration", "domain", "filestore", "-"}
+	types := []ItemType{ItemFile, ItemDirectory, ItemDpConfiguration, ItemDpDomain,
+		ItemDpFilestore, ItemDpObjectClass, ItemDpObject, ItemNone}
+	wantArr := []string{"file", "directory", "appliance configuration", "domain",
+		"filestore", "object class", "object", "-"}
 
 	for idx, gotType := range types {
 		got := gotType.UserFriendlyString()

--- a/repo/dp/dp.go
+++ b/repo/dp/dp.go
@@ -84,14 +84,14 @@ func (r *dpRepo) GetList(itemToShow *model.ItemConfig) (model.ItemList, error) {
 
 	if r.ObjectConfigMode {
 		switch itemToShow.Type {
-		case model.ItemDpDomain, model.ItemDpFilestore, model.ItemDirectory:
-			return r.listObjectClasses(itemToShow)
-		case model.ItemDpObjectClass:
-			return r.listObjects(itemToShow)
-		case model.ItemDpConfiguration:
+		case model.ItemDpDomain, model.ItemDpFilestore, model.ItemDirectory,
+			model.ItemDpConfiguration:
+			// For DP configuration we doesn't need to have domain name (but can have it).
 			if itemToShow.DpDomain != "" {
 				return r.listObjectClasses(itemToShow)
 			}
+		case model.ItemDpObjectClass:
+			return r.listObjects(itemToShow)
 		}
 		logging.LogDebugf("repo/dp/GetList(%v) - can't get children or item for ObjectConfigMode: %t.",
 			itemToShow, r.ObjectConfigMode)
@@ -1112,6 +1112,7 @@ func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemLis
 		return items, nil
 	// case config.DpInterfaceSoma:
 	default:
+		r.ObjectConfigMode = false
 		return nil, errs.Error("Object mode is supported only for REST management interface.")
 	}
 }

--- a/repo/dp/dp.go
+++ b/repo/dp/dp.go
@@ -1079,13 +1079,13 @@ func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemLis
 		if err != nil {
 			return nil, err
 		}
-		classNameMap := make(map[string]bool)
+		classNameMap := make(map[string]int)
 		classNames := make([]string, 0)
 		for _, className := range classNamesWithDuplicates {
 			if _, oldName := classNameMap[className]; !oldName {
-				classNameMap[className] = true
 				classNames = append(classNames, className)
 			}
+			classNameMap[className] = classNameMap[className] + 1
 		}
 
 		logging.LogDebugf("repo/dp/listObjectClasses(), classNames: %v", classNames)
@@ -1097,7 +1097,9 @@ func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemLis
 				DpDomain:    currentView.DpDomain,
 				Path:        className,
 				Parent:      currentView}
-			item := model.Item{Name: className, Config: &itemConfig}
+			item := model.Item{Name: className,
+				Size:   fmt.Sprintf("%d", classNameMap[className]),
+				Config: &itemConfig}
 			items[idx] = item
 		}
 

--- a/repo/dp/dp.go
+++ b/repo/dp/dp.go
@@ -1062,7 +1062,7 @@ func (r *dpRepo) listFiles(selectedItemConfig *model.ItemConfig) ([]model.Item, 
 
 // listObjectClasses lists all object classes used in current DataPower domain.
 func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemList, error) {
-	logging.LogDebugf("repo/dp/GetObjectClassList(%v)", currentView)
+	logging.LogDebugf("repo/dp/listObjectClasses(%v)", currentView)
 
 	if currentView.DpAppliance == "" {
 		return nil, errs.Error("Can't get object class list if DataPower appliance is not selected.")
@@ -1088,7 +1088,7 @@ func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemLis
 			}
 		}
 
-		logging.LogDebugf("repo/dp/GetObjectClassList(), classNames: %v", classNames)
+		logging.LogDebugf("repo/dp/listObjectClasses(), classNames: %v", classNames)
 
 		items := make(model.ItemList, len(classNames))
 		for idx, className := range classNames {
@@ -1103,7 +1103,7 @@ func (r *dpRepo) listObjectClasses(currentView *model.ItemConfig) (model.ItemLis
 
 		sort.Sort(items)
 
-		logging.LogDebugf("repo/dp/GetObjectClassList(), items: %v", items)
+		logging.LogDebugf("repo/dp/listObjectClasses(), items: %v", items)
 		return items, nil
 	// case config.DpInterfaceSoma:
 	default:

--- a/repo/dp/dp.go
+++ b/repo/dp/dp.go
@@ -88,12 +88,15 @@ func (r *dpRepo) GetList(itemToShow *model.ItemConfig) (model.ItemList, error) {
 			return r.listObjectClasses(itemToShow)
 		case model.ItemDpObjectClass:
 			return r.listObjects(itemToShow)
-		default:
-			logging.LogDebugf("repo/dp/GetList(%v) - can't get children or item for ObjectConfigMode: %t.",
-				itemToShow, r.ObjectConfigMode)
-			r.ObjectConfigMode = false
-			return nil, errs.Errorf("Can't show object view if DataPower domain is not selected.")
+		case model.ItemDpConfiguration:
+			if itemToShow.DpDomain != "" {
+				return r.listObjectClasses(itemToShow)
+			}
 		}
+		logging.LogDebugf("repo/dp/GetList(%v) - can't get children or item for ObjectConfigMode: %t.",
+			itemToShow, r.ObjectConfigMode)
+		r.ObjectConfigMode = false
+		return nil, errs.Errorf("Can't show object view if DataPower domain is not selected.")
 	} else {
 		switch itemToShow.Type {
 		case model.ItemNone:

--- a/repo/dp/dp.go
+++ b/repo/dp/dp.go
@@ -711,10 +711,6 @@ func (r *dpRepo) ExportDomain(domainName, exportFileName string) ([]byte, error)
 // GetObject fetches DataPower object configuration.
 func (r *dpRepo) GetObject(itemConfig *model.ItemConfig, objectName string) ([]byte, error) {
 	logging.LogDebugf("repo/dp/GetObject(%v, '%s')", itemConfig, objectName)
-	// https://localhost:5554/mgmt/status/tmp/ObjectStatus
-	// curl -k -u admin:admin https://localhost:5554/mgmt/ | jq .
-	// curl -k -u admin:admin https://localhost:5554/mgmt/config/ | jq . | less
-	// curl -k -u admin:admin https://localhost:5554/mgmt/config/tmp/XMLFirewallService | jq . | less
 
 	switch itemConfig.Type {
 	case model.ItemDpObject:

--- a/repo/dp/dp_test.go
+++ b/repo/dp/dp_test.go
@@ -3,6 +3,7 @@ package dp
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/clbanning/mxj"
 	"github.com/croz-ltd/dpcmder/model"
 	"github.com/croz-ltd/dpcmder/utils/errs"
 	"reflect"
@@ -107,6 +108,42 @@ func TestCleanJSONObject(t *testing.T) {
 	}
 	if string(gotJSON) != wantJSON {
 		t.Errorf("cleanJSONObject('%s'): got '%s', want '%s'", inputJSON, gotJSON, wantJSON)
+	}
+}
+
+func TestCleanXML(t *testing.T) {
+	inputXML := `<XMLFirewallService xmlns:_xmlns="xmlns" _xmlns:env="http://www.w3.org/2003/05/soap-envelope" name="parse-cert">
+  <mAdminState>enabled</mAdminState>
+  <LocalAddress>0.0.0.0</LocalAddress>
+  <HTTPVersion>
+    <Front>HTTP/1.1</Front>
+    <Back>HTTP/1.1</Back>
+  </HTTPVersion>
+  <DefaultParamNamespace>http://www.datapower.com/param/config</DefaultParamNamespace>
+  <DebugMode persisted="false">off</DebugMode>
+  <XMLManager class="XMLManager">default</XMLManager>
+</XMLFirewallService>`
+	wantXML := `<XMLFirewallService name="parse-cert">
+<mAdminState>enabled</mAdminState>
+<LocalAddress>0.0.0.0</LocalAddress>
+<HTTPVersion>
+  <Front>HTTP/1.1</Front>
+  <Back>HTTP/1.1</Back>
+</HTTPVersion>
+<DefaultParamNamespace>http://www.datapower.com/param/config</DefaultParamNamespace>
+<DebugMode>off</DebugMode>
+<XMLManager class="XMLManager">default</XMLManager>
+</XMLFirewallService>`
+
+	gotXML, _ := cleanXML(inputXML)
+
+	gotXMLBytes, _ := mxj.BeautifyXml([]byte(gotXML), "", "  ")
+	wantXMLBytes, _ := mxj.BeautifyXml([]byte(wantXML), "", "  ")
+	gotXML = string(gotXMLBytes)
+	wantXML = string(wantXMLBytes)
+
+	if gotXML != wantXML {
+		t.Errorf("for cleanXML('%s'): got '%s', want '%s'", inputXML, gotXML, wantXML)
 	}
 }
 

--- a/repo/dp/dp_test.go
+++ b/repo/dp/dp_test.go
@@ -19,19 +19,12 @@ func TestRemoveJSONKey(t *testing.T) {
     "asdf": 111,
     "keyrem": "valrem"
   },
-  "keysome2": {
-    "keyrem": "valrem"
-  }
+  "keysome2": { "keyrem": "valrem" }
 }`
 	wantJSON := `{
   "keyok": "valok",
-
-  "keysome1": {
-    "asdf": 111
-  }
-  "keysome2": {
-
-  }
+  "keysome1": { "asdf": 111 },
+  "keysome2": {}
 }`
 	var prettyJSON bytes.Buffer
 	json.Indent(&prettyJSON, []byte(wantJSON), "", "  ")

--- a/ui/worker.go
+++ b/ui/worker.go
@@ -462,7 +462,7 @@ func viewCurrent(m *model.Model) error {
 				return err
 			}
 			if fileContent != nil {
-				err = extprogs.View(ci.Name, fileContent)
+				err = extprogs.View("*."+ci.Name, fileContent)
 				if err != nil {
 					return err
 				}
@@ -478,7 +478,7 @@ func viewCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		err = extprogs.View(ci.Name+"*.json", fileContent)
+		err = extprogs.View("*."+ci.Name+".json", fileContent)
 		if err != nil {
 			return err
 		}
@@ -487,7 +487,7 @@ func viewCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		err = extprogs.View(ci.Name, objectContent)
+		err = extprogs.View(getObjectTmpName(ci.Name), objectContent)
 		if err != nil {
 			return err
 		}
@@ -512,7 +512,7 @@ func editCurrent(m *model.Model) error {
 			if err != nil {
 				return err
 			}
-			changed, newFileContent, err := extprogs.Edit(m.CurrItem().Name, fileContent)
+			changed, newFileContent, err := extprogs.Edit("*."+m.CurrItem().Name, fileContent)
 			if err != nil {
 				return err
 			}
@@ -554,17 +554,7 @@ func editCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		// Proper tmp file name can enable viewer / editor (vim) to highlight syntax.
-		var editName string
-		switch dp.Repo.GetManagementInterface() {
-		case config.DpInterfaceRest:
-			editName = ci.Name + "*.json"
-		case config.DpInterfaceSoma:
-			editName = ci.Name + "*.xml"
-		default:
-			return errs.Error("Unknown DP management interface used.")
-		}
-		changed, newObjectContent, err := extprogs.Edit(editName, objectContent)
+		changed, newObjectContent, err := extprogs.Edit(getObjectTmpName(ci.Name), objectContent)
 		if err != nil {
 			return err
 		}
@@ -1345,4 +1335,18 @@ func updateProgressDialog() {
 
 func updateProgressDialogMessagef(format string, v ...interface{}) {
 	progressDialogSession.msg = fmt.Sprintf(format, v...)
+}
+
+// getFileTypedName converts name without suffix to name with suffix - used for tmp
+// file naming. Proper tmp file name can enable viewer / editor (vim) to highlight syntax.
+func getObjectTmpName(objectName string) string {
+	switch dp.Repo.GetManagementInterface() {
+	case config.DpInterfaceRest:
+		return "*." + objectName + ".json"
+	case config.DpInterfaceSoma:
+		return "*." + objectName + ".xml"
+	default:
+		return objectName
+	}
+
 }

--- a/ui/worker.go
+++ b/ui/worker.go
@@ -478,7 +478,7 @@ func viewCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		err = extprogs.View(ci.Name, fileContent)
+		err = extprogs.View(ci.Name+"*.json", fileContent)
 		if err != nil {
 			return err
 		}
@@ -537,7 +537,7 @@ func editCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		changed, newFileContent, err := extprogs.Edit(m.CurrItem().Name, fileContent)
+		changed, newFileContent, err := extprogs.Edit(m.CurrItem().Name+"*.json", fileContent)
 		if err != nil {
 			return err
 		}
@@ -554,7 +554,17 @@ func editCurrent(m *model.Model) error {
 		if err != nil {
 			return err
 		}
-		changed, newObjectContent, err := extprogs.Edit(ci.Name, objectContent)
+		// Proper tmp file name can enable viewer / editor (vim) to highlight syntax.
+		var editName string
+		switch dp.Repo.GetManagementInterface() {
+		case config.DpInterfaceRest:
+			editName = ci.Name + "*.json"
+		case config.DpInterfaceSoma:
+			editName = ci.Name + "*.xml"
+		default:
+			return errs.Error("Unknown DP management interface used.")
+		}
+		changed, newObjectContent, err := extprogs.Edit(editName, objectContent)
 		if err != nil {
 			return err
 		}

--- a/ui/worker.go
+++ b/ui/worker.go
@@ -613,13 +613,20 @@ func diffCurrent(m *model.Model) error {
 	dpView := m.ViewConfig(model.Left)
 	localView := m.ViewConfig(model.Right)
 
-	if dpItem.Config.Type == localItem.Config.Type {
+	if dpItem.Config.Type == localItem.Config.Type || (dpItem.Config.Type == model.ItemDpFilestore && localItem.Config.Type == model.ItemDirectory) {
 		dpCopyDir := extprogs.CreateTempDir("dp")
 		updateStatusf("Created tmp dir on localfs '%s'", dpCopyDir)
 		localViewTmp := model.ItemConfig{Type: model.ItemDirectory, Path: dpCopyDir}
 		// func copyItem(fromRepo, toRepo repo.Repo, fromViewConfig, toViewConfig *model.ItemConfig, item model.Item, confirmOverwrite string) (string, error) {
 		copyItem(&dp.Repo, localfs.Repo, dpView, &localViewTmp, *dpItem, "y")
-		dpCopyItemPath := localfs.Repo.GetFilePath(dpCopyDir, dpItem.Name)
+		var dpDirName string
+		switch dpItem.Config.Type {
+		case model.ItemDpFilestore:
+			dpDirName = dpItem.Name[0 : len(dpItem.Name)-1]
+		default:
+			dpDirName = dpItem.Name
+		}
+		dpCopyItemPath := localfs.Repo.GetFilePath(dpCopyDir, dpDirName)
 		localItemPath := localfs.Repo.GetFilePath(localView.Path, localItem.Name)
 		err := extprogs.Diff(dpCopyItemPath, localItemPath)
 		if err != nil {

--- a/ui/worker.go
+++ b/ui/worker.go
@@ -563,8 +563,10 @@ func editCurrent(m *model.Model) error {
 			if err != nil {
 				return err
 			}
+			updateStatusf("DataPower object '%s' of class '%s' updated.", ci.Name, ci.Config.Path)
+		} else {
+			updateStatusf("DataPower object '%s' of class '%s' not changed.", ci.Name, ci.Config.Path)
 		}
-		updateStatusf("DataPower object '%s' of class '%s' updated.", ci.Name, ci.Config.Path)
 
 	default:
 		return errs.Errorf("Can't edit item '%s' (%s)", ci.Name, ci.Config.Type.UserFriendlyString())


### PR DESCRIPTION
Implementation of DataPower object mode toggle (filestore mode / object mode) by pressing '0' key.
In object mode we can view and edit all available DataPower objects in domain (organized in classes).
It makes small configuration changes much faster.
Maybe add possibility to clone and/or create new objects (in later case we should be able to switch between "used classes of objects" and "all classes of objects").